### PR TITLE
Support multary relation

### DIFF
--- a/treedlib/features.py
+++ b/treedlib/features.py
@@ -1,7 +1,7 @@
 from treedlib.templates import *
 import lxml.etree as et
 
-def compile_relation_feature_generator(dictionaries=None, opts={}):
+def compile_relation_feature_generator(dictionaries=None, opts={}, is_multary=False):
   """
   Given optional arguments, returns a generator function which accepts an xml root
   and two lists of mention indexes, and will generate relation features for this relation
@@ -9,6 +9,7 @@ def compile_relation_feature_generator(dictionaries=None, opts={}):
   Optional args are:
     * dictionaries: should be a dictionary of lists of phrases, where the key is the dict name
     * opts: see defaults above
+    * is_multary: whether to use multiple mentions or binary mentions
   """
   # TODO: put globals into opts
   #BASIC_ATTRIBS_REL = ['word', 'lemma', 'pos', 'ner', 'dep_label']
@@ -66,6 +67,8 @@ def compile_relation_feature_generator(dictionaries=None, opts={}):
       templates.append(DictionaryIntersect(SeqBetween(), d_name, d))
 
   # return generator function
+  if is_multary:
+    return Compile(templates).apply_multary_relation
   return Compile(templates).apply_relation
 
 """

--- a/treedlib/templates.py
+++ b/treedlib/templates.py
@@ -428,5 +428,8 @@ class Compile:
   def apply_relation(self, root, mention1_idxs, mention2_idxs, dict_sub={}, stopwords=None):
     return self.apply(root, [mention1_idxs, mention2_idxs], dict_sub=dict_sub, stopwords=stopwords)
   
+  def apply_multary_relation(self, root, mentions, dict_sub={}, stopwords=None):
+    return self.apply(root, mentions, dict_sub=dict_sub, stopwords=stopwords)
+  
   def __repr__(self):
     return '\n'.join(str(op) for op in self._iterops())


### PR DESCRIPTION
The `apply` function already supports a list of mentions, so why not give the possibility to get a relation of multiple mentions.

This is needed in order for [fonduer](https://github.com/HazyResearch/fonduer) to support multary candidates.